### PR TITLE
Add community badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # FiftyOne Plugin Examples 🔌🚀
 
+<div align="center">
+
+[![Discord](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/fiftyone-community)
+[![Hugging Face](https://img.shields.io/badge/Hugging_Face-purple?style=flat&logo=huggingface)](https://huggingface.co/Voxel51)
+[![Voxel51 Blog](https://img.shields.io/badge/Voxel51_Blog-ff6d04?style=flat)](https://voxel51.com/blog)
+[![Newsletter](https://img.shields.io/badge/Newsletter-BE5B25?logo=mail.ru&logoColor=white)](https://share.hsforms.com/1zpJ60ggaQtOoVeBqIZdaaA2ykyk)
+[![LinkedIn](https://img.shields.io/badge/In-white?style=flat&label=Linked&labelColor=blue)](https://www.linkedin.com/company/voxel51)
+[![Twitter](https://img.shields.io/badge/Twitter-000000?logo=x&logoColor=white)](https://x.com/voxel51)
+[![Medium](https://img.shields.io/badge/Medium-12100E?logo=medium&logoColor=white)](https://medium.com/voxel51)
+
+</div>
+
 > WIP: this repo is a work in progress!
 
 FiftyOne provides a powerful

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # FiftyOne Plugin Examples 🔌🚀
 
+<!-- markdownlint-disable no-inline-html -->
 <div align="center">
 
 [![Discord](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/fiftyone-community)
@@ -11,6 +12,7 @@
 [![Medium](https://img.shields.io/badge/Medium-12100E?logo=medium&logoColor=white)](https://medium.com/voxel51)
 
 </div>
+<!-- markdownlint-enable no-inline-html -->
 
 > WIP: this repo is a work in progress!
 


### PR DESCRIPTION
## Summary

- Adds a consistent set of community/social badges (Discord, Hugging Face,
  Blog, Newsletter, LinkedIn, Twitter/X, Medium) to the README
- Removes any outdated Slack community references
- Badges are placed on their own row, separate from code/developer badges

This is part of an org-wide effort to ensure consistent community links
across all Voxel51 repositories.