### PR TITLE
chore(workflows/pre-commit-dependabot-autoupdate): add sed command to…

### DIFF
--- a/.github/workflows/pre-commit-dependabot-autoupdate.yml
+++ b/.github/workflows/pre-commit-dependabot-autoupdate.yml
@@ -23,6 +23,15 @@ jobs:
           ref: main
           token: ${{ secrets.ORG_RO_ALOHA_GITHUB_WORKFLOWS_FG_PAT }}
           path: ./.github/actions/aloha-github-workflows
+      - name: Set generate-version-file action's path from remote to local
+        # Public repos cannot access private action repo without GitHub Enterprise
+        # Instead, we clone the private workflow directory and update the `asdf-install-and-cache/action.yml`
+        # file's reference to `voxel51/aloha-github-workflows/.github/actions/generate-version-file` with the local path.
+        shell: bash
+        run: |
+          sed -i \
+            's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
+            .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
       - name: Install asdf & tools
         uses: ./.github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache
       - name: Autoupdate Pre-commit Hooks


### PR DESCRIPTION
… update locally downloaded aloha-github-workflows repo to change from remote to local to overcome runtime errors.

# Rationale

The [pre-commit dependabot autoupdate](https://github.com/voxel51/fiftyone-plugin-examples/actions/workflows/pre-commit-dependabot-autoupdate.yml) actions in this repo are failing. Let's fix those.

Review Priority

* [ ] high
* [ ] medium
* [x] low

## Changes

Add sed command to access the private aloha-github-workflow repo from this public repo.

## Testing

See the successful run at https://github.com/voxel51/fiftyone-plugin-examples/actions/runs/23622801243

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
